### PR TITLE
fix: do not panic when given empty CMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ fn array() -> Parser<u8, Vec<Value>> {
 
 fn file() -> Parser<u8,Vec<Value>>
 {
-    ( comment().repeat(0..) * content_space() * value()).repeat(1..)
+    ( comment().repeat(0..) * content_space() * value()).repeat(0..)
 }
 
 pub fn parse(input: &[u8]) -> Result<Vec<Value>, pom::Error> {


### PR DESCRIPTION
The example PDF downloaded from [HumanEyesOnly](https://www.humaneyesonly.com) contains an empty CMap. It seems reasonable not to panic when encountering an empty CMap.